### PR TITLE
remove FirebaseRoot

### DIFF
--- a/Firebase.cpp
+++ b/Firebase.cpp
@@ -42,8 +42,6 @@ String Firebase::push(const String& value) {
 
 String Firebase::sendRequest(const char* method, const String& path, uint8_t* value, size_t size) {
   _error.reset();
-  Serial.print("host:");
-  Serial.println(_host);
   String url = "/" + path + ".json";
   if (_auth.length() > 0) {
     url += "?auth=" + _auth;

--- a/Firebase.cpp
+++ b/Firebase.cpp
@@ -28,21 +28,21 @@ Firebase& Firebase::auth(const String& auth) {
 }
 
 Firebase& Firebase::child(const String& key) {
-  _path += key;
+  _path = key;
   return *this;
 }
 
 String Firebase::val() {
-  return sendRequest("GET", _path);
+  return sendRequest("GET");
 }
 
 String Firebase::push(const String& value) {
-  return sendRequest("POST", _path, (uint8_t*)value.c_str(), value.length());
+  return sendRequest("POST", (uint8_t*)value.c_str(), value.length());
 }
 
-String Firebase::sendRequest(const char* method, const String& path, uint8_t* value, size_t size) {
+String Firebase::sendRequest(const char* method, uint8_t* value, size_t size) {
   _error.reset();
-  String url = "/" + path + ".json";
+  String url = "/" + _path + ".json";
   if (_auth.length() > 0) {
     url += "?auth=" + _auth;
   }

--- a/Firebase.h
+++ b/Firebase.h
@@ -54,7 +54,7 @@ class Firebase {
   String val();
   String push(const String& value);  
  private:
-  String sendRequest(const char* method, const String& path, uint8_t* value = NULL, size_t size = 0);
+  String sendRequest(const char* method, uint8_t* value = NULL, size_t size = 0);
   HTTPClient _http;
   String _host;
   String _auth;

--- a/Firebase.h
+++ b/Firebase.h
@@ -17,10 +17,6 @@
 // firebase-arduino is an Arduino client for Firebase.
 // It is currently limited to the ESP8266 board family.
 
-// TODO(proppy): add set() method for PUT.
-// TODO(proppy): add update() method for PATCH.
-// TODO(proppy): add remove() method for DELETE.
-// TODO(proppy): add connect() + non blocking
 #ifndef firebase_h
 #define firebase_h
 
@@ -29,27 +25,8 @@
 #include <WiFiClientSecure.h>
 #include <ESP8266HTTPClient.h>
 
-class FirebaseRoot;
-
-// FirebaseRef is a node in the firebase hierarchy.
-//
-// Methods val() and push() performs respectivly HTTP GET and POST
-// requests on the corresponding child reference and return the
-// response body.
-class FirebaseRef {
- public:
-  FirebaseRef(FirebaseRoot& root, const String& path);
-  FirebaseRef& root();
-  String val();  
-  String push(const String& value);
-  FirebaseRef child(const String& key);
- private:
-  FirebaseRoot& _root;
-  String _path;  
-};
-
-
-// FirebaseError is a string representation of a firebase HTTP error.
+// FirebaseError represents a Firebase API error with a code and a
+// message.
 class FirebaseError {
  public:
   operator bool() const { return _code < 0; }
@@ -65,27 +42,25 @@ class FirebaseError {
   String _message = "";
 };
 
-
-// FirebaseRoot is the root node of firebase hierarchy.
-//
-// A global `Firebase` instance is available for convenience, and need
-// to be initialized with the `begin()` and `auth()` methods.
-class FirebaseRoot : public FirebaseRef {
-  friend FirebaseRef;
+// Firebase is the connection to firebase.
+class Firebase {
  public:
-  FirebaseRoot();
-  FirebaseRoot& begin(const String& host);
-  FirebaseRoot& auth(const String& auth);
-  FirebaseRef child(const String& key);
-  const FirebaseError& error() { return _error; }
+  Firebase(const String& host);
+  Firebase& auth(const String& auth);
+  Firebase& child(const String& key);
+  const FirebaseError& error() const {
+    return _error;
+  }
+  String val();
+  String push(const String& value);  
  private:
   String sendRequest(const char* method, const String& path, uint8_t* value = NULL, size_t size = 0);
   HTTPClient _http;
   String _host;
   String _auth;
+  String _path;    
   FirebaseError _error;
 };
 
-extern FirebaseRoot Firebase;
 
 #endif // firebase_h

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This sample shows how to call [Firebase](https://www.firebase.com/) from the [ES
 
 - Clone the repo in your Arduino libraries directory.
 - open the `FirebasePush_ESP8266` example.
-- Replace `SSID` `PASSWORD` `example.firebaseio.com` `secret_or_token` `node` placeholders.
+- Replace `SSID` `PASSWORD` `example.firebaseio.com` `secret_or_token` `child_node` placeholders.
 
 ## Run
 

--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -46,6 +46,7 @@ void setup() {
       Serial.println(logs.error().message());
       return;
   }
+  // print response.
   Serial.println(l);
   // print all entries.
   Serial.println(logs.val());

--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -19,6 +19,11 @@
 
 #include <Firebase.h>
 
+// create firebase client.
+Firebase logs = Firebase("example.firebaseio.com")
+                   .auth("secret_or_token")
+                   .child("child_node");
+
 void setup() {
   Serial.begin(9600);
 
@@ -33,22 +38,17 @@ void setup() {
   Serial.print("connected: ");
   Serial.println(WiFi.localIP());
 
-  // get firebase child reference.
-  FirebaseRef logsRef = Firebase.begin("example.firebaseio.com")
-                                .auth("secret_or_token")
-                                .child("node");
-
   // add a new entry.
-  String logEntry = logsRef.push("{\".sv\": \"timestamp\"}");
+  String l = logs.push("{\".sv\": \"timestamp\"}");
   // handle error.
-  if (Firebase.error()) {
+  if (logs.error()) {
       Serial.println("Firebase request failed");
-      Serial.println(Firebase.error().message());
+      Serial.println(logs.error().message());
       return;
   }
-  Serial.println(logEntry);
+  Serial.println(l);
   // print all entries.
-  Serial.println(logsRef.val());
+  Serial.println(logs.val());
 }
 
 void loop() {


### PR DESCRIPTION
- remove `FirebaseRoot` type
- remove global `Firebase` object

Fixes #26.

For those lacking context on the change, it's mostly a refactoring to simplify the main Firebase object creation and work around global initialization order.

I'd suggest to look at the example code as a guide for the review:
https://github.com/proppy/firebase-iot-button/blob/remove-global/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino

/cc @leedenison @aliafshar @gguuss @beriberikix @tjohns 