### PR TITLE
Firebase: replace val by get

### DIFF
--- a/Firebase.cpp
+++ b/Firebase.cpp
@@ -27,7 +27,7 @@ Firebase& Firebase::auth(const String& auth) {
   return *this;
 }
 
-String Firebase::val(const String& path) {
+String Firebase::get(const String& path) {
   return sendRequest("GET", path);
 }
 

--- a/Firebase.h
+++ b/Firebase.h
@@ -50,7 +50,7 @@ class Firebase {
   const FirebaseError& error() const {
     return _error;
   }
-  String val(const String& path);
+  String get(const String& path);
   String push(const String& path, const String& value);
   bool connected();
   Firebase& stream(const String& path);

--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -48,7 +48,7 @@ void setup() {
   // print response.
   Serial.println(l);
   // print all entries.
-  Serial.println(fbase.val("/logs"));
+  Serial.println(fbase.get("/logs"));
 }
 
 void loop() {


### PR DESCRIPTION
As @mimming pointed out, `val(key)` is confusing because, in other fb lib it represents a client side operation to materialize a value from a synced cache, while our usage here is doing an active request.

Let's call that `get()`