### PR TITLE
Refactored Firebase library

### DIFF
--- a/Firebase.cpp
+++ b/Firebase.cpp
@@ -33,101 +33,48 @@ String makeUrl(const String& path, const String& auth) {
 
 }  // namespace
 
-Firebase::Firebase(const String& host) {
-  connection_.reset(new FirebaseConnection(host));
-}
-
-Firebase& Firebase::auth(const String& auth) {
-  connection_->auth(auth);
-  return *this;
-}
-
-FirebaseCall Firebase::get(const String& path) {
-  return FirebaseCall("GET", path, ++current_call_id_, connection_.get());
-}
-
-FirebaseCall Firebase::push(const String& path, const String& value) {
-  return FirebaseCall("POST", path, value, ++current_call_id_, connection_.get());
-}
-
-FirebaseCall Firebase::remove(const String& path) {
-  return FirebaseCall("DELETE", path, ++current_call_id_, connection_.get());
-}
-/*
-FirebaseEventStream Firebase::stream(const String& path) {
-  return FirebaseEventStream(host_, auth_, path);
-}*/
-
-/* FirebaseConnection */
-FirebaseConnection::FirebaseConnection(const String& host) : host_(host) {
+Firebase::Firebase(const String& host) : host_(host) {
   http_.setReuse(true);
 }
 
-FirebaseConnection& FirebaseConnection::auth(const String& auth) {
+Firebase& Firebase::auth(const String& auth) {
   auth_ = auth;
   return *this;
 }
 
-int FirebaseConnection::sendRequest(const char* method, const String& path, const String& value) {
-  const String url = makeUrl(path, auth_);
-  http_.begin(host_.c_str(), kFirebasePort, url.c_str(), true, kFirebaseFingerprint);
-  int status = http_.sendRequest(method, (uint8_t*)value.c_str(), value.length());
-  if (status == HTTP_CODE_OK) {
-    remaining_call_buffer_ = http_.getSize();
-  }
-  return status;
+FirebaseCall Firebase::get(const String& path) {
+  return FirebaseCall(host_, auth_, "GET", path, &http_);
 }
 
-String FirebaseConnection::getString() {
-  remaining_call_buffer_ = 0;
-  return http_.getString();
+FirebaseCall Firebase::push(const String& path, const String& value) {
+  return FirebaseCall(host_, auth_, "POST", path, value, &http_);
 }
 
-bool FirebaseConnection::isOwner(int call_id) {
-  return owning_call_id_ == call_id;
+FirebaseCall Firebase::remove(const String& path) {
+  return FirebaseCall(host_, auth_, "DELETE", path, &http_);
 }
 
-void FirebaseConnection::setOwner(int call_id) {
-  owning_call_id_ = call_id;
-  drainResponseBuffer();
-}
-
-void FirebaseConnection::drainResponseBuffer() {
-  auto* stream = http_.getStreamPtr();
-  Serial.println("Available ");
-  Serial.println(stream->available());
-
-
-  const int buffer_size = 128;
-  uint8_t buffer[buffer_size];
-  int read = 0;
-  int to_read = (buffer_size < remaining_call_buffer_) ? buffer_size : remaining_call_buffer_;
-  //TODO(edcoyne) This only reads what is available. Is this sufficient or should we wait?
-  while (remaining_call_buffer_ > 0 && (read = stream->read(buffer, to_read) > 0)) {
-    Serial.println("Draining ");
-    Serial.println(remaining_call_buffer_);
-    remaining_call_buffer_ -= read;
-    to_read = (buffer_size < remaining_call_buffer_) ? buffer_size : remaining_call_buffer_;
-  }
-  Serial.println("Done draining ");
-  Serial.println(remaining_call_buffer_);
+FirebaseEventStream Firebase::stream(const String& path) {
+  return FirebaseEventStream(host_, auth_, path);
 }
 
 /* FirebaseCall */
 
-FirebaseCall::FirebaseCall(const char* method, const String& path, const String& value,
-                           int call_id, FirebaseConnection* connection) 
-  : connection_(connection), call_id_(call_id) {
-  connection_->setOwner(call_id);
-  status_ = connection_->sendRequest(method, path, value);
+FirebaseCall::FirebaseCall(const String& host, const String& auth,
+                           const char* method, const String& path, const String& value,
+                           HTTPClient* http) : http_(http) {
+  const String url = makeUrl(path, auth);
+  http_->begin(host.c_str(), kFirebasePort, url.c_str(), true, kFirebaseFingerprint);
+  status_ =  http_->sendRequest(method, (uint8_t*)value.c_str(), value.length());
   if (isError()) {
-    error_message_ = String(method) + " " + path + ": " + HTTPClient::errorToString(status_);
+    error_message_ = String(method) + " " + url + ": " + HTTPClient::errorToString(status_);
   }
 }
 
-FirebaseCall::FirebaseCall(const char* method, const String& path, int call_id,
-                           FirebaseConnection* connection)
-    : FirebaseCall(method, path, "", call_id, connection) {}
+FirebaseCall::FirebaseCall(const String& host, const String& auth,
+                           const char* method, const String& path,
+                           HTTPClient* http) : FirebaseCall(host, auth, method, path, "", http) {
+}
 
 bool FirebaseCall::isOk() const {
   return status_ == HTTP_CODE_OK;
@@ -142,16 +89,7 @@ String FirebaseCall::errorMessage() const {
 }
 
 String FirebaseCall::rawResponse() {
-  if (!connection_->isOwner(call_id_)) {
-    setErrorNotOwner();
-    return "";
-  }
-  return connection_->getString();
-}
-
-void FirebaseCall::setErrorNotOwner() {
-  status_ = kStatusNotConnectionOwner;
-  error_message_ = "Connection no longer owns connection";
+  return http_->getString();
 }
 
 /* FirebaseEventStream */

--- a/Firebase.h
+++ b/Firebase.h
@@ -28,9 +28,13 @@
 class FirebaseResult {
  public:
   FirebaseResult(int status);
+  FirebaseResult(int status, const String& response);
+  FirebaseResult(const FirebaseResult& result);
+
   bool isError() const;
   bool isOk() const;
   String errorMessage() const;
+  const String& response() const;
 
   int httpStatus() const {
     return status_;
@@ -38,19 +42,7 @@ class FirebaseResult {
 
  protected:
   int status_;
-};
-
-class FirebaseResultWithMessage : public FirebaseResult {
- public:
-  FirebaseResultWithMessage(int status, const String& message);
-  FirebaseResultWithMessage(const FirebaseResult& result,
-                            const String& message);
-
-  // Check isError() before calling this.
-  const String& message() const;
-
- private:
-  String message_ ;
+  String response_;
 };
 
 class FirebaseConnection {
@@ -71,8 +63,8 @@ class FirebaseConnection {
   FirebaseResult sendRequest(const char* method, const String& path, const String& value);
   FirebaseResult sendRequest(const char* method, const String& path);
 
-  FirebaseResultWithMessage sendRequestGetBody(const char* method, const String& path);
-  FirebaseResultWithMessage sendRequestGetBody(const char* method, const String& path, const String& value);
+  FirebaseResult sendRequestGetBody(const char* method, const String& path);
+  FirebaseResult sendRequestGetBody(const char* method, const String& path, const String& value);
 
  private:
   HTTPClient http_;
@@ -88,10 +80,10 @@ class Firebase {
 
   // Fetch result at "path" to a local variable. If the value is too large you will exceed
   // local memory.
-  FirebaseResultWithMessage get(const String& path);
+  FirebaseResult get(const String& path);
 
   // Add new value to list at "path", will return child name of new item.
-  FirebaseResultWithMessage push(const String& path, const String& value);
+  FirebaseResult push(const String& path, const String& value);
 
   // Deletes value at "path" from server.
   FirebaseResult remove(const String& path);

--- a/Firebase.h
+++ b/Firebase.h
@@ -52,6 +52,7 @@ class Firebase {
   }
   String get(const String& path);
   String push(const String& path, const String& value);
+  bool remove(const String& path);
   bool connected();
   Firebase& stream(const String& path);
   bool available();
@@ -63,7 +64,10 @@ class Firebase {
   Event read(String& event);
  private:
   String makeURL(const String& path);
-  String sendRequest(const char* method, const String& path, const String& value = "");
+  int sendRequest(const char* method, const String& path, const String& value = "");
+  String sendRequestGetBody(const char* method, const String& path, const String& value = "");
+  void setError(const char* method, const String& url, int status_code);
+
   HTTPClient _http;
   String _host;
   String _auth;

--- a/Firebase.h
+++ b/Firebase.h
@@ -27,6 +27,34 @@
 
 //TODO(edcoyne) split these into multiple files.
 
+class FirebaseCall;
+class FirebaseEventStream;
+
+// Primary client to the Firebase backend.
+class Firebase {
+ public:
+  Firebase(const String& host);
+  Firebase& auth(const String& auth);
+
+  // Fetch result at "path" to a local variable. If the value is too large you will exceed
+  // local memory.
+  FirebaseCall get(const String& path);
+
+  // Add new value to list at "path", will return child name of new item.
+  FirebaseCall push(const String& path, const String& value);
+
+  // Deletes value at "path" from server.
+  FirebaseCall remove(const String& path);
+
+  // Starts a stream of events that effect object at "path".
+  FirebaseEventStream stream(const String& path);
+
+ private:
+  HTTPClient http_;
+  String host_;
+  String auth_;
+};
+
 class FirebaseCall {
  public:
   FirebaseCall(const String& host, const String& auth,
@@ -90,28 +118,4 @@ class FirebaseEventStream {
   String error_message_;
 };
 
-// Primary client to the Firebase backend.
-class Firebase {
- public:
-  Firebase(const String& host);
-  Firebase& auth(const String& auth);
-
-  // Fetch result at "path" to a local variable. If the value is too large you will exceed
-  // local memory.
-  FirebaseCall get(const String& path);
-
-  // Add new value to list at "path", will return child name of new item.
-  FirebaseCall push(const String& path, const String& value);
-
-  // Deletes value at "path" from server.
-  FirebaseCall remove(const String& path);
-
-  // Starts a stream of events that effect object at "path".
-  FirebaseEventStream stream(const String& path);
-
- private:
-  HTTPClient http_;
-  String host_;
-  String auth_;
-};
 #endif // firebase_h

--- a/Firebase.h
+++ b/Firebase.h
@@ -36,8 +36,7 @@ class Firebase {
   Firebase(const String& host);
   Firebase& auth(const String& auth);
 
-  // Fetch result at "path" to a local variable. If the value is too large you will exceed
-  // local memory.
+  // Fetch result at "path".
   FirebaseGetResult get(const String& path);
 
   // Add new value to list at "path", will return child name of new item.
@@ -58,8 +57,7 @@ class Firebase {
   String auth_;
 };
 
-
-// Result from a Firebase call.
+// Base class for Results from a Firebase call.
 class FirebaseResult {
  public:
   // Constructor for error result.
@@ -144,8 +142,6 @@ class FirebaseEventStream {
     PUT,
     PATCH
   };
-
-  FirebaseEventStream(const String& host, const String& auth, const String& path);
 
   // Read next event in stream.
   Event read(String& event);

--- a/Firebase.h
+++ b/Firebase.h
@@ -25,26 +25,36 @@
 #include <WiFiClientSecure.h>
 #include <ESP8266HTTPClient.h>
 
+//TODO(edcoyne) split these into multiple files.
+
+// Result from call to Firebase backend. ALWAYS check isError() before
+// expecting any data.
 class FirebaseResult {
  public:
   FirebaseResult(int status);
   FirebaseResult(int status, const String& response);
   FirebaseResult(const FirebaseResult& result);
 
+  // True if there was an error completeing call.
   bool isError() const;
-  bool isOk() const;
   String errorMessage() const;
+
+  // True if http status code is 200(OK).
+  bool isOk() const;
+  // Message sent back from Firebase backend.
   const String& response() const;
 
   int httpStatus() const {
     return status_;
   }
 
- protected:
+ private:
   int status_;
   String response_;
 };
 
+// Low level connection to Firebase backend, you probably want the
+// Firebase class below.
 class FirebaseConnection {
  public:
   FirebaseConnection(const String& host);
@@ -72,7 +82,7 @@ class FirebaseConnection {
   String auth_;
 };
 
-// Firebase is the connection to firebase.
+// Primary client to the Firebase backend.
 class Firebase {
  public:
   Firebase(const String& host);
@@ -104,14 +114,19 @@ class FirebaseEventStream {
   FirebaseEventStream(const String& host);
   FirebaseEventStream& auth(const String& auth);
 
+  // Connect to backend and start receiving events.
   FirebaseResult connect(const String& path);
+  // Read next event in stream.
   Event read(String& event);
 
+  // True if connected to backend.
   bool connected();
+
+  // True if there is an event available.
   bool available();
+
  private:
   FirebaseConnection connection_;
 };
-
 
 #endif // firebase_h

--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -37,18 +37,22 @@ void setup() {
   Serial.print("connected: ");
   Serial.println(WiFi.localIP());
 
-  // add a new entry.
-  String l = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
-  // handle error.
-  if (fbase.error()) {
+   // add a new entry.
+  FirebaseResultWithMessage push = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
+  if (push.isError()) {
       Serial.println("Firebase request failed");
-      Serial.println(fbase.error().message());
+      Serial.println(push.errorMessage());  
       return;
   }
+
   // print response.
-  Serial.println(l);
+  Serial.println(push.message());
+  
   // print all entries.
-  Serial.println(fbase.get("/logs"));
+  FirebaseResultWithMessage fetch = fbase.get("/logs");
+  if (!fetch.isError()) {
+    Serial.println(fetch.message());
+  }
 }
 
 void loop() {

--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -38,7 +38,7 @@ void setup() {
   Serial.println(WiFi.localIP());
 
    // add a new entry.
-  FirebaseResultWithMessage push = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
+  FirebaseResult push = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
   if (push.isError()) {
       Serial.println("Firebase request failed");
       Serial.println(push.errorMessage());  
@@ -49,7 +49,7 @@ void setup() {
   Serial.println(push.message());
   
   // print all entries.
-  FirebaseResultWithMessage fetch = fbase.get("/logs");
+  FirebaseResult fetch = fbase.get("/logs");
   if (!fetch.isError()) {
     Serial.println(fetch.message());
   }

--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -38,20 +38,20 @@ void setup() {
   Serial.println(WiFi.localIP());
 
    // add a new entry.
-  FirebaseCall push = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
-  if (push.isError()) {
+  FirebasePushResult push = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
+  if (!push) {
       Serial.println("Firebase request failed");
       Serial.println(push.errorMessage());  
       return;
   }
 
   // print response.
-  Serial.println(push.rawResponse());
+  Serial.println(push.name());
   
   // print all entries.
-  FirebaseCall fetch = fbase.get("/logs");
-  if (!fetch.isError()) {
-    Serial.println(fetch.rawResponse());
+  FirebaseGetResult get = fbase.get("/logs");
+  if (get) {
+    Serial.println(get.rawResponse());
   }
 }
 

--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -38,7 +38,7 @@ void setup() {
   Serial.println(WiFi.localIP());
 
    // add a new entry.
-  FirebaseResult push = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
+  FirebaseCall push = fbase.push("/logs", "{\".sv\": \"timestamp\"}");
   if (push.isError()) {
       Serial.println("Firebase request failed");
       Serial.println(push.errorMessage());  
@@ -46,12 +46,12 @@ void setup() {
   }
 
   // print response.
-  Serial.println(push.message());
+  Serial.println(push.rawResponse());
   
   // print all entries.
-  FirebaseResult fetch = fbase.get("/logs");
+  FirebaseCall fetch = fbase.get("/logs");
   if (!fetch.isError()) {
-    Serial.println(fetch.message());
+    Serial.println(fetch.rawResponse());
   }
 }
 

--- a/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
+++ b/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
@@ -24,8 +24,8 @@
 #define OLED_RESET 10
 Adafruit_SSD1306 display(OLED_RESET);
 
-FirebaseEventStream fbase = FirebaseEventStream("publicdata-cryptocurrency.firebaseio.com");
-FirebaseResult connectionResult;
+Firebase fbase = Firebase("publicdata-cryptocurrency.firebaseio.com");
+FirebaseEventStream stream;
 
 void setup() {
   Serial.begin(9600);
@@ -44,19 +44,19 @@ void setup() {
   Serial.print("connected: ");
   Serial.println(WiFi.localIP());
   
-  connectionResult = fbase.connect("/bitcoin");
+  stream = fbase.stream("/bitcoin");
 }
 
 
 void loop() {  
-  if (connectionResult.isError()) {
+  if (stream.isError()) {
     Serial.println("streaming error");
-    Serial.println(connectionResult.errorMessage());
+    Serial.println(stream.errorMessage());
   }
   
-  if (fbase.available()) {
+  if (stream.available()) {
      String event;
-     auto type = fbase.read(event);
+     auto type = stream.read(event);
      Serial.print("event: ");
      Serial.println(type);
      if (type != FirebaseEventStream::Event::UNKNOWN) {

--- a/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
+++ b/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
@@ -47,7 +47,7 @@ void setup() {
 
 void loop() {  
   static FirebaseEventStream stream = fbase.stream("/bitcoin");
-  if (stream.isError()) {
+  if (!stream) {
     Serial.println("streaming error");
     Serial.println(stream.errorMessage());
   }

--- a/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
+++ b/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
@@ -24,7 +24,8 @@
 #define OLED_RESET 10
 Adafruit_SSD1306 display(OLED_RESET);
 
-Firebase fbase = Firebase("publicdata-cryptocurrency.firebaseio.com");
+FirebaseEventStream fbase = FirebaseEventStream("publicdata-cryptocurrency.firebaseio.com");
+FirebaseResult connectionResult;
 
 void setup() {
   Serial.begin(9600);
@@ -43,21 +44,22 @@ void setup() {
   Serial.print("connected: ");
   Serial.println(WiFi.localIP());
   
-  fbase.stream("/bitcoin");
+  connectionResult = fbase.connect("/bitcoin");
 }
 
 
-void loop() {
-  if (fbase.error()) {
+void loop() {  
+  if (connectionResult.isError()) {
     Serial.println("streaming error");
-    Serial.println(fbase.error().message());
+    Serial.println(connectionResult.errorMessage());
   }
+  
   if (fbase.available()) {
      String event;
      auto type = fbase.read(event);
      Serial.print("event: ");
      Serial.println(type);
-     if (type != Firebase::Event::UNKNOWN) {
+     if (type != FirebaseEventStream::Event::UNKNOWN) {
        Serial.print("data: ");
        Serial.println(event);
      
@@ -69,5 +71,5 @@ void loop() {
        display.println(event);
        display.display();
      }
-  } 
+  }   
 }

--- a/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
+++ b/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
@@ -25,7 +25,6 @@
 Adafruit_SSD1306 display(OLED_RESET);
 
 Firebase fbase = Firebase("publicdata-cryptocurrency.firebaseio.com");
-FirebaseEventStream stream;
 
 void setup() {
   Serial.begin(9600);
@@ -43,12 +42,11 @@ void setup() {
   Serial.println();
   Serial.print("connected: ");
   Serial.println(WiFi.localIP());
-  
-  stream = fbase.stream("/bitcoin");
 }
 
 
 void loop() {  
+  static FirebaseEventStream stream = fbase.stream("/bitcoin");
   if (stream.isError()) {
     Serial.println("streaming error");
     Serial.println(stream.errorMessage());


### PR DESCRIPTION
As discussed in issue #41 

Refactored to provide result and not depend on class state for error reporting, conform to Google C++ style.

Also broke FirebaseEventStream out from Firebase. When this is connected I believe any other calls (push,fetch,etc..) to the class would break it. For that reason it really seems like this should be its own focused class. Or you need large comments explaining this gotcha.