### PR TITLE
Fix streaming parsing

### DIFF
--- a/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
+++ b/examples/FirebaseStream_ESP8266/FirebaseStream_ESP8266.ino
@@ -44,7 +44,7 @@ void setup() {
   Serial.println();
   Serial.print("connected: ");
   Serial.println(WiFi.localIP());
-  stream = fbase.stream("/bitcoin");  
+  stream = fbase.stream("/bitcoin/last");  
 }
 
 
@@ -65,7 +65,7 @@ void loop() {
        Serial.println(event);
        JsonObject& json = buf.parseObject((char*)event.c_str());
        String path = json["path"];
-       float data = json["data"]["last"];       
+       float data = json["data"];       
      
        // TODO(proppy): parse JSON object.
        display.clearDisplay();


### PR DESCRIPTION
So my previous fix only fixed the first result in the stream. All of the others are of a different format. However if we ask for the /last value directly all results look the same.

Didn't see this before because the job updating the bitcoin database was down and it wasn't seeing any updates but that is fixed now.