### PR TITLE
Firebase serial

### DIFF
--- a/Firebase.cpp
+++ b/Firebase.cpp
@@ -160,11 +160,18 @@ FirebaseSet::FirebaseSet(const String& host, const String& auth,
     json_ = response();
   }
 }
+
 // FirebasePush
 FirebasePush::FirebasePush(const String& host, const String& auth,
                            const String& path, const String& value,
-                           HTTPClient* http)
-  : FirebaseCall(host, auth, "POST", path, value, http) {
+                           HTTPClient* http) {
+  begin(host, auth, path, value, http);
+}
+
+void FirebasePush::begin(const String& host, const String& auth,
+                         const String& path, const String& value,
+                         HTTPClient* http) {
+  FirebaseCall::begin(host, auth, "POST", path, value, http);
   if (!error()) {
     // TODO: parse name
     name_ = response();
@@ -212,6 +219,9 @@ FirebaseStream::Event FirebaseStream::read(String& event) {
 }
 
 void FirebaseSerial::begin(const String& host, const String& auth, const String& path) {
+  host_ = host;
+  auth_ = auth;
+  path_ = path;
   stream_.begin(host, auth, path, &httpStream_);
 }
 
@@ -223,4 +233,8 @@ String FirebaseSerial::read() {
   String event;
   auto type = stream_.read(event);
   return event;
+}
+
+void FirebaseSerial::print(String data) {
+  push_.begin(host_, auth_, path_, data, &httpPush_);
 }

--- a/Firebase.h
+++ b/Firebase.h
@@ -131,6 +131,8 @@ class FirebasePush : public FirebaseCall {
   FirebasePush() {}
   FirebasePush(const String& host, const String& auth,
                const String& path, const String& value, HTTPClient* http = NULL);
+  void begin(const String& host, const String& auth,
+             const String& path, const String& value, HTTPClient* http = NULL);
 
   const String& name() const {
     return name_;
@@ -180,14 +182,19 @@ class FirebaseStream : public FirebaseCall {
 class FirebaseSerial {
  public:
   FirebaseSerial() {}
-  void begin(const String& url, const String& auth = "", const String& path = "/");
+  void begin(const String& host, const String& auth = "", const String& path = "/");
   bool available();
   String read();
+  void print(String data);
 
  private:
-  HTTPClient http_;
+  String host_;
+  String auth_;
+  String path_;
   HTTPClient httpStream_;
   FirebaseStream stream_;
+  HTTPClient httpPush_;
+  FirebasePush push_;
 };
 
 #endif // firebase_h

--- a/Firebase.h
+++ b/Firebase.h
@@ -34,7 +34,11 @@ class FirebaseStream;
 // Firebase REST API client.
 class Firebase {
  public:
-  Firebase(const String& host);
+  Firebase();
+  Firebase(const String& host, const String& auth = "");
+  void begin(const String& host, const String& auth = "");
+
+  Firebase& host(const String& host);
   Firebase& auth(const String& auth);
 
   // Fetch json encoded `value` at `path`.
@@ -62,11 +66,11 @@ class FirebaseError {
  public:
   FirebaseError() {}
   FirebaseError(int code, const String& message) : code_(code), message_(message) {
-  }  
+  }
   operator bool() const { return code_ != 0; }
   int code() const { return code_; }
   const String& message() const { return message_; }
- private:  
+ private:
   int code_ = 0;
   String message_ = "";
 };
@@ -76,8 +80,12 @@ class FirebaseCall {
   FirebaseCall() {}
   FirebaseCall(const String& host, const String& auth,
                const char* method, const String& path,
-               const String& data = "",        
+               const String& data = "",
                HTTPClient* http = NULL);
+  void begin(const String& host, const String& auth,
+             const char* method, const String& path,
+             const String& data = "",
+             HTTPClient* http = NULL);
   const FirebaseError& error() const {
     return error_;
   }
@@ -95,7 +103,7 @@ class FirebaseGet : public FirebaseCall {
   FirebaseGet() {}
   FirebaseGet(const String& host, const String& auth,
               const String& path, HTTPClient* http = NULL);
-  
+
   const String& json() const {
     return json_;
   }
@@ -145,7 +153,9 @@ class FirebaseStream : public FirebaseCall {
   FirebaseStream() {}
   FirebaseStream(const String& host, const String& auth,
                  const String& path, HTTPClient* http = NULL);
-  
+  void begin(const String& host, const String& auth,
+             const String& path, HTTPClient* http = NULL);
+
   // Return if there is any event available to read.
   bool available();
 
@@ -157,14 +167,27 @@ class FirebaseStream : public FirebaseCall {
   };
 
   // Read next json encoded `event` from stream.
-  Event read(String& event);  
+  Event read(String& event);
 
   const FirebaseError& error() const {
     return _error;
   }
-  
+
  private:
   FirebaseError _error;
+};
+
+class FirebaseSerial {
+ public:
+  FirebaseSerial() {}
+  void begin(const String& url, const String& auth = "", const String& path = "/");
+  bool available();
+  String read();
+
+ private:
+  HTTPClient http_;
+  HTTPClient httpStream_;
+  FirebaseStream stream_;
 };
 
 #endif // firebase_h

--- a/examples/FirebaseSerial_ESP8266/FirebaseSerial_ESP8266.ino
+++ b/examples/FirebaseSerial_ESP8266/FirebaseSerial_ESP8266.ino
@@ -1,0 +1,45 @@
+//
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// FirebaseStream_ESP8266 is a sample that stream bitcoin price from a
+// public Firebase and optionally display them on a OLED i2c screen.
+
+#include <Firebase.h>
+
+FirebaseSerial firebaseSerial;
+
+void setup() {
+  Serial.begin(9600);
+  firebaseSerial.begin("example.firebaseio.com", "secret");
+
+  // connect to wifi.
+  WiFi.begin("GoogleGuest", "PASSWORD");
+  Serial.print("connecting");
+  while (WiFi.status() != WL_CONNECTED) {
+    Serial.print(".");
+    delay(500);
+  }
+  Serial.println();
+  Serial.print("connected: ");
+  Serial.println(WiFi.localIP());
+}
+
+
+void loop() {
+  if (firebaseSerial.available()) {
+    Serial.print(firebaseSerial.read());
+  }   
+}


### PR DESCRIPTION
A simpler API inspired by https://konekt.io/ that expose a Serial-port like interface over a firebase path.

- `read()` will stream event data
- `write()` will push data

We could add a prefix for write to do `set()` maybe `*`.

`get()` is a subset of `stream()` because the stream start by yielding existing values.