### PR TITLE
json: switch json() to readJson()

### DIFF
--- a/src/Firebase.cpp
+++ b/src/Firebase.cpp
@@ -118,11 +118,12 @@ FirebaseCall::FirebaseCall(const String& host, const String& auth,
   }
 }
 
-const JsonObject& FirebaseCall::json() {
-  //TODO(edcoyne): This is not efficient, we should do something smarter with
+JsonObject& FirebaseCall::parseJson() {
+  // TODO(edcoyne): This is not efficient, we should do something smarter with
   //the buffers.
   buffer_ = DynamicJsonBuffer();
-  return buffer_.parseObject(response());
+  // NOTE(proppy): this effectively void the response_ buffer.
+  return buffer_.parseObject(const_cast<char*>(response_.c_str()));
 }
 
 // FirebaseGet
@@ -132,15 +133,16 @@ FirebaseGet::FirebaseGet(const String& host, const String& auth,
   : FirebaseCall(host, auth, "GET", path, "", http) {
 }
 
+JsonObject& FirebaseGet::readJson() {
+  return parseJson();
+}
+
+
 // FirebaseSet
 FirebaseSet::FirebaseSet(const String& host, const String& auth,
        const String& path, const String& value,
        HTTPClient* http)
   : FirebaseCall(host, auth, "PUT", path, value, http) {
-  if (!error()) {
-    // TODO: parse json
-    json_ = response();
-  }
 }
 // FirebasePush
 FirebasePush::FirebasePush(const String& host, const String& auth,
@@ -148,7 +150,7 @@ FirebasePush::FirebasePush(const String& host, const String& auth,
                            HTTPClient* http)
   : FirebaseCall(host, auth, "POST", path, value, http) {
   if (!error()) {
-    name_ = json()["name"].as<const char*>();
+    name_ = parseJson()["name"].as<const char*>();;
   }
 }
 

--- a/src/Firebase.h
+++ b/src/Firebase.h
@@ -63,11 +63,11 @@ class FirebaseError {
  public:
   FirebaseError() {}
   FirebaseError(int code, const String& message) : code_(code), message_(message) {
-  }  
+  }
   operator bool() const { return code_ != 0; }
   int code() const { return code_; }
   const String& message() const { return message_; }
- private:  
+ private:
   int code_ = 0;
   String message_ = "";
 };
@@ -77,20 +77,15 @@ class FirebaseCall {
   FirebaseCall() {}
   FirebaseCall(const String& host, const String& auth,
                const char* method, const String& path,
-               const String& data = "",        
+               const String& data = "",
                HTTPClient* http = NULL);
   const FirebaseError& error() const {
     return error_;
   }
-
-  const String& response() {
-    return response_;
-  }
-
-  const JsonObject& json();
-
  protected:
+  JsonObject& parseJson();
   HTTPClient* http_;
+ private:
   FirebaseError error_;
   String response_;
   DynamicJsonBuffer buffer_;
@@ -101,9 +96,7 @@ class FirebaseGet : public FirebaseCall {
   FirebaseGet() {}
   FirebaseGet(const String& host, const String& auth,
               const String& path, HTTPClient* http = NULL);
-
- private:
-  String json_;
+  JsonObject& readJson();
 };
 
 class FirebaseSet: public FirebaseCall {
@@ -111,9 +104,6 @@ class FirebaseSet: public FirebaseCall {
   FirebaseSet() {}
   FirebaseSet(const String& host, const String& auth,
 	      const String& path, const String& value, HTTPClient* http = NULL);
-
- private:
-  String json_;
 };
 
 class FirebasePush : public FirebaseCall {
@@ -155,7 +145,7 @@ class FirebaseStream : public FirebaseCall {
   };
 
   // Read next json encoded `event` from stream.
-  Event read(String& event);  
+  Event read(String& event);
 
   const FirebaseError& error() const {
     return _error;


### PR DESCRIPTION
- pass the response as a mutable buffer to get rid of the leaking [strdup()](https://github.com/bblanchon/ArduinoJson/blob/master/include/ArduinoJson/JsonBuffer.hpp#L89).
- rename the function to make it more obvious it's only meant to be called once.
- delete obsolete json_ field.
- make response_ and other FirebaseCall member private.