### PR TITLE
add travis for arduino/esp8266

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: c
 sudo: false
 env:
-- ARDUINO_VERSION=1.6.8
-- ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION}
+- ARDUINO_VERSION=1.6.8 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION}
 install:
 - cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-1.6.5-linux64.tar.xz
 after_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ sudo: false
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
 script:
+  - find $HOME
   - build_platform esp8266

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: c
 sudo: false
 env:
 - ARDUINO_VERSION=1.6.8 ARDUINO_ESP8266_VERSION=2.1.0 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266 ARDUINO_HOME=${HOME}/Arduino
+- ARDUINO_VERSION=1.6.8 ARDUINO_ESP8266_VERSION=2.2.0-rc1 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266 ARDUINO_HOME=${HOME}/Arduino
+- ARDUINO_VERSION=nightly ARDUINO_ESP8266_VERSION=master ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266 ARDUINO_HOME=${HOME}/Arduino
 install:
 - ( cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz )
 - git clone --branch ${ARDUINO_ESP8266_VERSION} https://github.com/esp8266/Arduino.git ${ARDUINO_ESP8266_ROOT}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
 - ARDUINO_VERSION=1.6.8 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION}
 install:
-- cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-1.6.5-linux64.tar.xz
+- cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz
 after_install:
 - mkdir -p Arduino/libraries
 - ln -s firebase-arduino Arduino/libraries/firebase-arduino

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ sudo: false
 env:
 - ARDUINO_VERSION=1.6.8 ARDUINO_ESP8266_VERSION=2.1.0 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266 ARDUINO_HOME=${HOME}/Arduino
 install:
+- env
 - cd ${HOME}
 - curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz
 - tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz
 - git clone --branch ${ARDUINO_ESP8266_VERSION} https://github.com/esp8266/Arduino.git ${ARDUINO_ESP8266_ROOT}
 - cd ${ARDUINO_ESP8266_ROOT}/tools && python get.py
+before_script:
 - mkdir -p ${ARDUINO_HOME}/libraries
-- cd ${ARDUINO_HOME}/libraries && ln -s ${HOME}/firebase-arduino && ln -s ${HOME}/firebase-arduino/src/third-party/arduino-json-5.1.1
+- cd ${ARDUINO_HOME}/libraries && ln -s ${TRAVIS_BUILD_DIR} firebase-arduino && ln -s ${TRAVIS_BUILD_DIR}/src/third-party/arduino-json-5.1.1 ArduinoJson
 script:
-- ${ARDUINO_ROOT}/arduino-builder -verbose  -hardware ${ARDUINO_ROOT}/hardware/ -tools ${ARDUINO_ESP8266_ROOT}/tools/ -tools ${ARDUINO_ROOT}/tools-builder/ -fqbn esp8266com:esp8266:nodemcuv2 -libraries ${HOME}/Arduino/libraries/ -prefs build.flash_ld=${ARDUINO_ESP8266_ROOT}/tools/sdk/ld/eagle.flash.4m.ld -prefs build.flash_freq=40 -prefs build.flash_size=4M examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+- ${ARDUINO_ROOT}/arduino-builder -verbose  -hardware ${ARDUINO_ROOT}/hardware/ -tools ${ARDUINO_ESP8266_ROOT}/tools/ -tools ${ARDUINO_ROOT}/tools-builder/ -fqbn esp8266com:esp8266:nodemcuv2 -libraries ${ARDUINO_HOME}/libraries/ -prefs build.flash_ld=${ARDUINO_ESP8266_ROOT}/tools/sdk/ld/eagle.flash.4m.ld -prefs build.flash_freq=40 -prefs build.flash_size=4M examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 install:
 - cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz
 - git clone --branch ${ARDUINO_ESP8266_VERSION} https://github.com/esp8266/Arduino.git ${ARDUINO_ESP8266_ROOT}
-- python ${ARDUINO_ESP8266_ROOT}/tools/get.py
+- cd ${ARDUINO_ESP8266_ROOT}/tools && python get.py
 after_install:
 - mkdir -p Arduino/libraries
 - ln -s firebase-arduino Arduino/libraries/firebase-arduino

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ sudo: false
 env:
 - ARDUINO_VERSION=1.6.8 ARDUINO_ESP8266_VERSION=2.1.0 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266 ARDUINO_HOME=${HOME}/Arduino
 install:
-- env
-- cd ${HOME}
-- curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz
-- tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz
+- ( cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz )
 - git clone --branch ${ARDUINO_ESP8266_VERSION} https://github.com/esp8266/Arduino.git ${ARDUINO_ESP8266_ROOT}
-- cd ${ARDUINO_ESP8266_ROOT}/tools && python get.py
+- ( cd ${ARDUINO_ESP8266_ROOT}/tools && python get.py )
 before_script:
 - mkdir -p ${ARDUINO_HOME}/libraries
-- cd ${ARDUINO_HOME}/libraries && ln -s ${TRAVIS_BUILD_DIR} firebase-arduino && ln -s ${TRAVIS_BUILD_DIR}/src/third-party/arduino-json-5.1.1 ArduinoJson
+- ( cd ${ARDUINO_HOME}/libraries && ln -s ${TRAVIS_BUILD_DIR} firebase-arduino && ln -s ${TRAVIS_BUILD_DIR}/src/third-party/arduino-json-5.1.1 ArduinoJson )
 script:
 - ${ARDUINO_ROOT}/arduino-builder -verbose  -hardware ${ARDUINO_ROOT}/hardware/ -tools ${ARDUINO_ESP8266_ROOT}/tools/ -tools ${ARDUINO_ROOT}/tools-builder/ -fqbn esp8266com:esp8266:nodemcuv2 -libraries ${ARDUINO_HOME}/libraries/ -prefs build.flash_ld=${ARDUINO_ESP8266_ROOT}/tools/sdk/ld/eagle.flash.4m.ld -prefs build.flash_freq=40 -prefs build.flash_size=4M examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+sudo: false
+before_install:
+  - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
+script:
+  - build_platform esp8266

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: c
 sudo: false
-before_install:
-  - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
+env:
+- ARDUINO_VERSION=1.6.8
+- ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION}
+install:
+- cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-1.6.5-linux64.tar.xz
+after_install:
+- mkdir -p Arduino/libraries
+- ln -s firebase-arduino Arduino/libraries/firebase-arduino
+- ln -s firebase-arduino/src/third-party/arduino-json-5.1.1 Arduino/libraries/ArduinoJson
 script:
-  - find /home/travis/.arduino15
-  - build_platform esp8266
+- ${ARDUINO_ROOT}/arduino-builder -verbose  -hardware ${ARDUINO_ROOT}/hardware/ -tools ${ARDUINO_ROOT}/hardware/esp8266com/esp8266/tools/ -tools ${ARDUINO_ROOT}/tools-builder/ -fqbn esp8266com:esp8266:nodemcuv2 -libraries ~/Arduino/libraries -prefs build.flash_ld=${ARDUINO_ROOT}/hardware/esp8266com/esp8266/tools/sdk/ld/eagle.flash.4m.ld -prefs build.flash_freq=40 -prefs build.flash_size=4M firebase-arduino/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: c
 sudo: false
 env:
-- ARDUINO_VERSION=1.6.8 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION}
+- ARDUINO_VERSION=1.6.8 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_VERSION=2.1.0 ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266
 install:
 - cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz
+- git clone --branch ${ARDUINO_ESP8266_VERSION} https://github.com/esp8266/Arduino.git ${ARDUINO_ESP8266_ROOT}
+- python ${ARDUINO_ESP8266_ROOT}/tools/get.py
 after_install:
 - mkdir -p Arduino/libraries
 - ln -s firebase-arduino Arduino/libraries/firebase-arduino

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ sudo: false
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
 script:
-  - find $HOME
+  - find /home/travis/.arduino15
   - build_platform esp8266

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: c
 sudo: false
 env:
-- ARDUINO_VERSION=1.6.8 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_VERSION=2.1.0 ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266
+- ARDUINO_VERSION=1.6.8 ARDUINO_ESP8266_VERSION=2.1.0 ARDUINO_ROOT=${HOME}/arduino-${ARDUINO_VERSION} ARDUINO_ESP8266_ROOT=${ARDUINO_ROOT}/hardware/esp8266com/esp8266 ARDUINO_HOME=${HOME}/Arduino
 install:
-- cd ${HOME} && curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz && tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz
+- cd ${HOME}
+- curl -O https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz
+- tar xvf arduino-${ARDUINO_VERSION}-linux64.tar.xz
 - git clone --branch ${ARDUINO_ESP8266_VERSION} https://github.com/esp8266/Arduino.git ${ARDUINO_ESP8266_ROOT}
 - cd ${ARDUINO_ESP8266_ROOT}/tools && python get.py
-after_install:
-- mkdir -p Arduino/libraries
-- ln -s firebase-arduino Arduino/libraries/firebase-arduino
-- ln -s firebase-arduino/src/third-party/arduino-json-5.1.1 Arduino/libraries/ArduinoJson
+- mkdir -p ${ARDUINO_HOME}/libraries
+- cd ${ARDUINO_HOME}/libraries && ln -s ${HOME}/firebase-arduino && ln -s ${HOME}/firebase-arduino/src/third-party/arduino-json-5.1.1
 script:
-- ${ARDUINO_ROOT}/arduino-builder -verbose  -hardware ${ARDUINO_ROOT}/hardware/ -tools ${ARDUINO_ROOT}/hardware/esp8266com/esp8266/tools/ -tools ${ARDUINO_ROOT}/tools-builder/ -fqbn esp8266com:esp8266:nodemcuv2 -libraries ~/Arduino/libraries -prefs build.flash_ld=${ARDUINO_ROOT}/hardware/esp8266com/esp8266/tools/sdk/ld/eagle.flash.4m.ld -prefs build.flash_freq=40 -prefs build.flash_size=4M firebase-arduino/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+- ${ARDUINO_ROOT}/arduino-builder -verbose  -hardware ${ARDUINO_ROOT}/hardware/ -tools ${ARDUINO_ESP8266_ROOT}/tools/ -tools ${ARDUINO_ROOT}/tools-builder/ -fqbn esp8266com:esp8266:nodemcuv2 -libraries ${HOME}/Arduino/libraries/ -prefs build.flash_ld=${ARDUINO_ESP8266_ROOT}/tools/sdk/ld/eagle.flash.4m.ld -prefs build.flash_freq=40 -prefs build.flash_size=4M examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino


### PR DESCRIPTION
This add travis jobs for the following combination of arduino and esp8266 cores:

| Arduino | ESP8266 |
| --- | --- |
| 1.6.8 | 2.1.0 |
| 1.6.8 | 2.2.0-rc1 |
| nightly | master |

This will hopefully helps to to catch future breakage.

Fixes #56.
