### PR TITLE
firebase: fix ctor

### DIFF
--- a/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
+++ b/examples/FirebasePush_ESP8266/FirebasePush_ESP8266.ino
@@ -20,8 +20,8 @@
 #include <Firebase.h>
 
 // create firebase client.
-Firebase fbase = Firebase("example.firebaseio.com")
-                   .auth("secret_or_token");
+Firebase fbase("example.firebaseio.com", "secret_or_token");
+
 void setup() {
   Serial.begin(9600);
 

--- a/src/Firebase.cpp
+++ b/src/Firebase.cpp
@@ -40,13 +40,8 @@ String makeFirebaseURL(const String& path, const String& auth) {
 
 }  // namespace
 
-Firebase::Firebase(const String& host) : host_(host) {
+Firebase::Firebase(const String& host, const String& auth) : host_(host), auth_(auth) {
   http_.setReuse(true);
-}
-
-Firebase& Firebase::auth(const String& auth) {
-  auth_ = auth;
-  return *this;
 }
 
 FirebaseGet Firebase::get(const String& path) {

--- a/src/Firebase.h
+++ b/src/Firebase.h
@@ -35,8 +35,7 @@ class FirebaseStream;
 // Firebase REST API client.
 class Firebase {
  public:
-  Firebase(const String& host);
-  Firebase& auth(const String& auth);
+  Firebase(const String& host, const String& auth = "");
 
   // Fetch json encoded `value` at `path`.
   FirebaseGet get(const String& path);


### PR DESCRIPTION
Change firebase construction to be saner and avoid calling the copy constructor.

We should probably also add `begin()`.

This should make the new esp-travis integration merged in #88 pass for all arduino/esp combination.

