### PR TITLE
Fixing deprecation warning on HttpClient begin

### DIFF
--- a/src/FirebaseHttpClient_Esp8266.cpp
+++ b/src/FirebaseHttpClient_Esp8266.cpp
@@ -28,7 +28,7 @@ class FirebaseHttpClientEsp8266 : public FirebaseHttpClient {
   }
 
   void begin(const std::string& host, const std::string& path) override {
-    http_.begin(host.c_str(), kFirebasePort, path.c_str(), true, kFirebaseFingerprint);
+    http_.begin(host.c_str(), kFirebasePort, path.c_str(), kFirebaseFingerprint);
   }
 
   void end() override {


### PR DESCRIPTION
Was getting the following warnings:
/Users/foo/Documents/Arduino/libraries/firebase-arduino-master/src/FirebaseHttpClient_Esp8266.cpp: In member function 'virtual void FirebaseHttpClientEsp8266::begin(const string&, const string&)':
/Users/foo/Documents/Arduino/libraries/firebase-arduino-master/src/FirebaseHttpClient_Esp8266.cpp:31:86: warning: 'bool HTTPClient::begin(String, uint16_t, String, bool, String)' is deprecated (declared at /Users/foo/Library/Arduino15/packages/esp8266/hardware/esp8266/2.3.0/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h:141) [-Wdeprecated-declarations]
     http_.begin(host.c_str(), kFirebasePort, path.c_str(), true, kFirebaseFingerprint);

Followed the recommendation at https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h:
`
bool begin(String host, uint16_t port, String uri, String httpsFingerprint);
// deprecated, use the overload above instead
bool begin(String host, uint16_t port, String uri, bool https, String httpsFingerprint)  __attribute__ ((deprecated));
`
